### PR TITLE
Specify outputfile

### DIFF
--- a/addon/email
+++ b/addon/email
@@ -253,8 +253,7 @@ if {$mail(AttType) == "local"} {
     set AttNewName [file tail $mailAttachment]
 
 } elseif {$mail(AttType) == "snapshot"} {
-    exec wget --no-check-certificate -q -r -nd --user=$mailSnapuser --password=$mailSnappass --auth-no-challenge -O /usr/local/etc/config/addons/email/tmp/$AttName "$mailAttachment"
-    exec mv /usr/local/etc/config/addons/email/tmp/$AttName /usr/local/etc/config/addons/email/tmp/snapshot.jpg
+    exec wget --no-check-certificate -q -r -nd --user=$mailSnapuser --password=$mailSnappass --auth-no-challenge -O /usr/local/etc/config/addons/email/tmp/snapshot.jpg "$mailAttachment"
     set fp [open "/usr/local/etc/config/addons/email/tmp/snapshot.jpg" r]
     fconfigure $fp -translation binary
     set imgdata [read $fp]

--- a/addon/email
+++ b/addon/email
@@ -253,7 +253,7 @@ if {$mail(AttType) == "local"} {
     set AttNewName [file tail $mailAttachment]
 
 } elseif {$mail(AttType) == "snapshot"} {
-    exec wget --no-check-certificate -q -r -nd --user=$mailSnapuser --password=$mailSnappass --auth-no-challenge -P /usr/local/etc/config/addons/email/tmp/ "$mailAttachment"
+    exec wget --no-check-certificate -q -r -nd --user=$mailSnapuser --password=$mailSnappass --auth-no-challenge -O /usr/local/etc/config/addons/email/tmp/$AttName "$mailAttachment"
     exec mv /usr/local/etc/config/addons/email/tmp/$AttName /usr/local/etc/config/addons/email/tmp/snapshot.jpg
     set fp [open "/usr/local/etc/config/addons/email/tmp/snapshot.jpg" r]
     fconfigure $fp -translation binary


### PR DESCRIPTION
I had a problem when I wanted to send an snapshot from MJPEG-Streamer. The URL to get the snapshot is "http://192.168.158.65:8080/?action=snapshot" but when it is downloaded with wget the filename is "index.html?action=snapshot" The script expects that the filename is "?action=snapshot" (in this example), because wget renames the file it is not found. So you have to specify the output filename in the wget command.